### PR TITLE
Alamb/bad example

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,13 +37,16 @@ async fn process_socket(mut socket: TcpStream) -> Result<()> {
 async fn aworker() {
     println!("Running a worker job");
     loop {
+        // Give other tasks a chance to work
         let count = get_count().await;
         heavy_stuff(count);
+        tokio::task::yield_now().await;
     }
 }
 
 async fn get_count() -> u64 {
-    20000000
+    //20000000
+    200000
 }
 
 fn heavy_stuff(count: u64) -> u64 {


### PR DESCRIPTION
This PR demonstrates 

It can be made much better by adding a call to `tokio::task::yield_now();` 

Though 25 seconds is quite a long time to wait
alamb@ip-10-0-0-124 ~ % time echo foo | socat -t30 - TCP:localhost:1234
echo foo  0.00s user 0.00s system 18% cpu 0.004 total
socat -t30 - TCP:localhost:1234  0.00s user 0.00s system 0% cpu 25.777 total

If we break the work chunks into smaller pieces, say 200000 instead of 20000000 then the ping response time drops down nicely:

```
echo foo  0.00s user 0.00s system 22% cpu 0.004 total
socat -t30 - TCP:localhost:1234  0.00s user 0.00s system 1% cpu 0.415 total
```
